### PR TITLE
Revert "Issue #1710656 by mikeytown2 - If item is hidden in _menu_tree_check_access() skip it right away."

### DIFF
--- a/includes/menu.inc
+++ b/includes/menu.inc
@@ -1039,11 +1039,6 @@ function _menu_tree_check_access(&$tree) {
   $new_tree = array();
   foreach ($tree as $key => $v) {
     $item = &$tree[$key]['link'];
-    // Do not load hidden menu items if not in active breadcrumb trail and
-    // user can't administer the menu.
-    if (!empty($item['hidden']) && empty($item['in_active_trail']) && !user_access('administer menu')) {
-      continue;
-    }
     _menu_link_translate($item);
     if ($item['access']) {
       if ($tree[$key]['below']) {


### PR DESCRIPTION
This reverts commit 0a30619066ec47461401f6aa6ad19138b98f2547 as we run into the
problem, where an editor without 'administer menu' permissions disabled a menu
item (using og_menu module) can't enable it again.